### PR TITLE
Add command to stop tensorboard session (#26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,13 @@
                 "enablement": "tensorboard.hasActiveTensorBoardSession",
                 "icon": "$(refresh)",
                 "title": "%refreshTensorBoard.title%"
+            },
+            {
+                "category": "Python",
+                "command": "tensorboard.stop",
+                "enablement": "tensorboard.hasActiveTensorBoardSession",
+                "icon": "$(refresh)",
+                "title": "%stopTensorBoard.title%"
             }
         ],
         "menus": {
@@ -73,6 +80,14 @@
                     "enablement": "tensorboard.hasActiveTensorBoardSession",
                     "icon": "$(refresh)",
                     "title": "%refreshTensorBoard.title%",
+                    "when": "!virtualWorkspace && isWorkspaceTrusted"
+                },
+                {
+                    "category": "Python",
+                    "command": "tensorboard.stop",
+                    "enablement": "tensorboard.hasActiveTensorBoardSession",
+                    "icon": "$(stop)",
+                    "title": "%stopTensorBoard.title%",
                     "when": "!virtualWorkspace && isWorkspaceTrusted"
                 }
             ]

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,5 +2,6 @@
     "tensorBoard.log.description": "The logging level the extension logs at.",
     "tensorBoard.logDirectory.description": "Set this setting to your preferred TensorBoard log directory to skip log directory prompt when starting TensorBoard.",
     "launchTensorBoard.title": "Launch TensorBoard",
-    "refreshTensorBoard.title": "Refresh TensorBoard"
+    "refreshTensorBoard.title": "Refresh TensorBoard",
+    "stopTensorBoard.title": "Stop TensorBoard"
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export enum TensorBoardSessionStartResult {
 export namespace Commands {
   export const LaunchTensorBoard = 'tensorboard.launch';
   export const RefreshTensorBoard = 'tensorboard.refresh';
+  export const StopTensorBoard = 'tensorboard.stop';
 }
 
 export const PYTHON_LANGUAGE = 'python';

--- a/src/sessionProvider.ts
+++ b/src/sessionProvider.ts
@@ -44,6 +44,9 @@ export class TensorBoardSessionProvider extends BaseDisposable {
         this._register(
             commands.registerCommand(Commands.RefreshTensorBoard, () => this.knownSessions.map((w) => w.refresh()))
         );
+        this._register(
+            commands.registerCommand(Commands.StopTensorBoard, () => this.knownSessions.map((w) => w.stop()))
+        );
     }
     private updateTensorBoardSessionContext() {
         let hasActiveTensorBoardSession = false;


### PR DESCRIPTION
Add command to stop TensorBoard session (#26)

Implements a command to stop the TensorBoard session within the command palette, addressing feature #26.

## Changes
- Added new command to command palette `Python: Stop TensorBoard` that terminates all active tb sessions
- Removed success condition in `startTensorBoardSession()` as this condition is never met
- Replaced success condition check with implicit assignment of the process object, allows it to be terminated later with `stop()`
- Removed auto termination of process on web view panel disposal, allows browser to remain active while closing it in vscode

## Testing
- Manually tested starting and stopping TensorBoard sessions in WSL2
- Verified TensorBoard sessions continue running when the webview panel is closed
- Verified command appears correctly in command palette, only seen when there is an active tb session
- Ran `npm run test` successfully using specified version in contribution guidelines

## Related
Implements feature request #26