### PR TITLE
extension: require VS Code 1.97

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "vscode": "^1.85.0"
+                "vscode": "^1.97.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "theme": "light"
     },
     "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.97.0"
     },
     "l10n": "./l10n",
     "keywords": [


### PR DESCRIPTION
## Summary

- raise `engines.vscode` from `^1.85.0` to `^1.97.0` so every admitted stable VS Code product authorizes the requested `portsAttributes` proposal
- keep the root package-lock metadata synchronized

## Compatibility evidence

- shipped VS Code 1.96.4 does not authorize `portsAttributes` for `ms-toolsai.tensorboard`
- shipped VS Code 1.97.0 is the first release that authorizes it
- both stable and pre-release pipelines inherit the shared publishing templates covered by microsoft/vscode-engineering#3705

Related: microsoft/vscode-remote-release#11815

## Validation

- `npm run package` with the CI runtime (Node 20.18.1, npm 10.8.2, VSCE 3.9.2)
- proposed API compatibility gate against the packaged VSIX: 1 package validated across 83 admitted stable VS Code products through 1.135.0
- `git diff --check`
- three independent reviewers found no blocking issues